### PR TITLE
Fix for download course videos which does not have name

### DIFF
--- a/src/download/getVideos.js
+++ b/src/download/getVideos.js
@@ -33,7 +33,11 @@ function getVideos(url, token) {
           filterSpan.map(el => {
             if (el.name === 'div') {
               const index = Number(el.parent.attribs['data-index']);
-              const videoName = `${index + 1} ` + el.children[0].data.replace(/[\/:*?"<>|]/g, '');
+              let videoName;
+              if(el.children[0])
+                videoName = `${index + 1} ` + el.children[0].data.replace(/[\/:*?"<>|]/g, '');
+              else
+                videoName = 'Lesson '+`${index + 1}`;
               names.push(videoName);
             }
           });


### PR DESCRIPTION
Added changes to remove error when Downloading  course videos which does not have names -like this one -https://coursehunters.net/course/frontendmaster-deep-foundations-of-advanced-js