### PR TITLE
Fixed DOM query to retrieve the lessons container

### DIFF
--- a/src/download/getVideos.js
+++ b/src/download/getVideos.js
@@ -7,7 +7,7 @@ request = request.defaults({
 });
 
 const videoMaterialScriptContainerSelector =
-  ".flex-player-item .main-content script:nth-of-type(3)";
+  ".main-content script:nth-of-type(3)";
 
 const getCourseId = ($) => {
   const lessonsScriptContainer = $(videoMaterialScriptContainerSelector);


### PR DESCRIPTION
They removed the `.flex-player-item` class from the DOM so the program is not getting videos anymore.
After removing this, it's working again :)
